### PR TITLE
Fix datetime format in logs

### DIFF
--- a/supervisor_checks/check_runner.py
+++ b/supervisor_checks/check_runner.py
@@ -186,7 +186,7 @@ class CheckRunner(object):
         :param str msg: string message.
         """
 
-        curr_dt = datetime.datetime.now().strftime('%Y/%M/%d %H:%M:%S')
+        curr_dt = datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')
 
         sys.stderr.write(
             '%s [%s] %s\n' % (curr_dt, self._name, msg % args,))


### PR DESCRIPTION
## Second datetime parameter is Minute, but should be a Month

**Actual** datetime format: `%Y/%M/%d %H:%M:%S` where 
`%M` - Minute as a zero-padded decimal number.
But **expected**:
`%m` - Month as a zero-padded decimal number.

As a result we have following incorrect messages in log _(Let's say today is 23 March 2017)_:
```
2017/04/23 05:04:01 [rando-health-check] Received TICK_60 event from supervisor
2017/05/23 05:05:01 [rando-health-check] Received TICK_60 event from supervisor
```

With fixed datetime format log will be following:

```
2017/03/23 05:04:01 [rando-health-check] Received TICK_60 event from supervisor
2017/03/23 05:05:01 [rando-health-check] Received TICK_60 event from supervisor
```


