### PR TITLE
Added argument to pass in process name directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Process check based on HTTP query.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
+      -pn PROCESS_NAME, --process-name PROCESS_NAME
+                            Supervisor process name. Process group argument is
+                            ignored if this is passed in
       -u URL, --url URL     HTTP check url
       -p PORT, --port PORT  HTTP port to query. Can be integer or regular
                             expression which will be used to extract port from a
@@ -152,6 +155,9 @@ Process check based on TCP connection status.
                             Check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
+      -pn PROCESS_NAME, --process-name PROCESS_NAME
+                            Supervisor process name. Process group argument is
+                            ignored if this is passed in
       -p PORT, --port PORT  TCP port to query. Can be integer or regular
                             expression which will be used to extract port from a
                             process name.
@@ -196,6 +202,9 @@ Process check based on call to XML RPC server.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
+      -pn PROCESS_NAME, --process-name PROCESS_NAME
+                            Supervisor process name. Process group argument is
+                            ignored if this is passed in
       -u URL, --url URL     XML RPC check url
       -s SOCK_PATH, --socket-path SOCK_PATH
                             Full path to XML RPC server local socket
@@ -250,6 +259,9 @@ Process check based on amount of memory consumed by process.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
+      -pn PROCESS_NAME, --process-name PROCESS_NAME
+                            Supervisor process name. Process group argument is
+                            ignored if this is passed in
       -m MAX_RSS, --msx-rss MAX_RSS
                             Maximum memory allowed to use by process, KB.
       -c CUMULATIVE, --cumulative CUMULATIVE
@@ -282,6 +294,9 @@ Process check based on CPU percent usage within specified time interval.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
+      -pn PROCESS_NAME, --process-name PROCESS_NAME
+                            Supervisor process name. Process group argument is
+                            ignored if this is passed in
       -p MAX_CPU, --max-cpu-percent MAX_CPU
                             Maximum CPU percent usage allowed to use by process
                             within time interval.
@@ -317,6 +332,9 @@ Complex check(run multiple checks at once).
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
+      -pn PROCESS_NAME, --process-name PROCESS_NAME
+                            Supervisor process name. Process group argument is
+                            ignored if this is passed in
       -c CHECK_CONFIG, --check-config CHECK_CONFIG
                             Check config in JSON format
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Process check based on HTTP query.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
-      -pn PROCESS_NAME, --process-name PROCESS_NAME
+      -N PROCESS_NAME, --process-name PROCESS_NAME
                             Supervisor process name. Process group argument is
                             ignored if this is passed in
       -u URL, --url URL     HTTP check url
@@ -155,7 +155,7 @@ Process check based on TCP connection status.
                             Check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
-      -pn PROCESS_NAME, --process-name PROCESS_NAME
+      -N PROCESS_NAME, --process-name PROCESS_NAME
                             Supervisor process name. Process group argument is
                             ignored if this is passed in
       -p PORT, --port PORT  TCP port to query. Can be integer or regular
@@ -202,7 +202,7 @@ Process check based on call to XML RPC server.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
-      -pn PROCESS_NAME, --process-name PROCESS_NAME
+      -N PROCESS_NAME, --process-name PROCESS_NAME
                             Supervisor process name. Process group argument is
                             ignored if this is passed in
       -u URL, --url URL     XML RPC check url
@@ -259,7 +259,7 @@ Process check based on amount of memory consumed by process.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
-      -pn PROCESS_NAME, --process-name PROCESS_NAME
+      -N PROCESS_NAME, --process-name PROCESS_NAME
                             Supervisor process name. Process group argument is
                             ignored if this is passed in
       -m MAX_RSS, --msx-rss MAX_RSS
@@ -294,7 +294,7 @@ Process check based on CPU percent usage within specified time interval.
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
-      -pn PROCESS_NAME, --process-name PROCESS_NAME
+      -N PROCESS_NAME, --process-name PROCESS_NAME
                             Supervisor process name. Process group argument is
                             ignored if this is passed in
       -p MAX_CPU, --max-cpu-percent MAX_CPU
@@ -332,7 +332,7 @@ Complex check(run multiple checks at once).
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
-      -pn PROCESS_NAME, --process-name PROCESS_NAME
+      -N PROCESS_NAME, --process-name PROCESS_NAME
                             Supervisor process name. Process group argument is
                             ignored if this is passed in
       -c CHECK_CONFIG, --check-config CHECK_CONFIG

--- a/supervisor_checks/bin/complex_check.py
+++ b/supervisor_checks/bin/complex_check.py
@@ -39,7 +39,7 @@ def _make_argument_parser():
                         type=str, required=True, default=None,
                         help='Health check name.')
     parser.add_argument('-g', '--process-group', dest='process_group',
-                        type=str, required=True, default=None,
+                        type=str, default=None,
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,

--- a/supervisor_checks/bin/complex_check.py
+++ b/supervisor_checks/bin/complex_check.py
@@ -41,7 +41,7 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, default=None,
                         help='Supervisor process group name.')
-    parser.add_argument('-pn', '--process-name', dest='process_name',
+    parser.add_argument('-N', '--process-name', dest='process_name',
                         type=str, default=None,
                         help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')

--- a/supervisor_checks/bin/complex_check.py
+++ b/supervisor_checks/bin/complex_check.py
@@ -41,6 +41,10 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, required=True, default=None,
                         help='Supervisor process group name.')
+    parser.add_argument('-pn', '--process-name', dest='process_name',
+                        type=str, default=None,
+                        help='Supervisor process name. Process group argument is ignored if this' +
+                             'is passed in')
     parser.add_argument('-c', '--check-config', dest='check_config', type=str,
                         help='Check config JSON', required=True, default=None)
 
@@ -61,7 +65,7 @@ def main():
         checks_config.append((CHECK_CLASSES[check_name], check_config))
 
     return check_runner.CheckRunner(
-        args.check_name, args.process_group, checks_config).run()
+        args.check_name, args.process_group, args.process_name, checks_config).run()
 
 
 if __name__ == '__main__':

--- a/supervisor_checks/bin/complex_check.py
+++ b/supervisor_checks/bin/complex_check.py
@@ -43,7 +43,7 @@ def _make_argument_parser():
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,
-                        help='Supervisor process name. Process group argument is ignored if this' +
+                        help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')
     parser.add_argument('-c', '--check-config', dest='check_config', type=str,
                         help='Check config JSON', required=True, default=None)

--- a/supervisor_checks/bin/cpu_check.py
+++ b/supervisor_checks/bin/cpu_check.py
@@ -30,6 +30,10 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, required=True, default=None,
                         help='Supervisor process group name.')
+    parser.add_argument('-pn', '--process-name', dest='process_name',
+                        type=str, default=None,
+                        help='Supervisor process name. Process group argument is ignored if this' +
+                             'is passed in')
     parser.add_argument(
         '-p', '--max-cpu-percent', dest='max_cpu', type=int, required=True,
         help='Maximum CPU percent usage allowed to use by process '
@@ -51,7 +55,7 @@ def main():
                                      'interval': args.interval})]
 
     return check_runner.CheckRunner(
-        args.check_name, args.process_group, checks_config).run()
+        args.check_name, args.process_group, args.process_name, checks_config).run()
 
 
 if __name__ == '__main__':

--- a/supervisor_checks/bin/cpu_check.py
+++ b/supervisor_checks/bin/cpu_check.py
@@ -32,7 +32,7 @@ def _make_argument_parser():
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,
-                        help='Supervisor process name. Process group argument is ignored if this' +
+                        help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')
     parser.add_argument(
         '-p', '--max-cpu-percent', dest='max_cpu', type=int, required=True,

--- a/supervisor_checks/bin/cpu_check.py
+++ b/supervisor_checks/bin/cpu_check.py
@@ -28,7 +28,7 @@ def _make_argument_parser():
                         type=str, required=True, default=None,
                         help='Health check name.')
     parser.add_argument('-g', '--process-group', dest='process_group',
-                        type=str, required=True, default=None,
+                        type=str, default=None,
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,

--- a/supervisor_checks/bin/cpu_check.py
+++ b/supervisor_checks/bin/cpu_check.py
@@ -30,7 +30,7 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, default=None,
                         help='Supervisor process group name.')
-    parser.add_argument('-pn', '--process-name', dest='process_name',
+    parser.add_argument('-N', '--process-name', dest='process_name',
                         type=str, default=None,
                         help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')

--- a/supervisor_checks/bin/http_check.py
+++ b/supervisor_checks/bin/http_check.py
@@ -26,8 +26,11 @@ def _make_argument_parser():
                         type=str, required=True, default=None,
                         help='Health check name.')
     parser.add_argument('-g', '--process-group', dest='process_group',
-                        type=str, required=True, default=None,
+                        type=str, default=None,
                         help='Supervisor process group name.')
+    parser.add_argument('-pn', '--process-name', dest='process_name',
+                        type=str, default=None,
+                        help='Supervisor process name. Process group argument is ignored if this is passed in')
     parser.add_argument('-u', '--url', dest='url', type=str,
                         help='HTTP check url', required=True, default=None)
     parser.add_argument('-U', '--username', dest='username', type=str,
@@ -67,7 +70,7 @@ def main():
                                        })]
 
     return check_runner.CheckRunner(
-        args.check_name, args.process_group, checks_config).run()
+        args.check_name, args.process_group, args.process_name, checks_config).run()
 
 
 if __name__ == '__main__':

--- a/supervisor_checks/bin/http_check.py
+++ b/supervisor_checks/bin/http_check.py
@@ -30,7 +30,8 @@ def _make_argument_parser():
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,
-                        help='Supervisor process name. Process group argument is ignored if this is passed in')
+                        help='Supervisor process name. Process group argument is ignored if this ' +
+                             'is passed in')
     parser.add_argument('-u', '--url', dest='url', type=str,
                         help='HTTP check url', required=True, default=None)
     parser.add_argument('-U', '--username', dest='username', type=str,

--- a/supervisor_checks/bin/http_check.py
+++ b/supervisor_checks/bin/http_check.py
@@ -28,7 +28,7 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, default=None,
                         help='Supervisor process group name.')
-    parser.add_argument('-pn', '--process-name', dest='process_name',
+    parser.add_argument('-N', '--process-name', dest='process_name',
                         type=str, default=None,
                         help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')

--- a/supervisor_checks/bin/memory_check.py
+++ b/supervisor_checks/bin/memory_check.py
@@ -29,7 +29,7 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, default=None,
                         help='Supervisor process group name.')
-    parser.add_argument('-pn', '--process-name', dest='process_name',
+    parser.add_argument('-N', '--process-name', dest='process_name',
                         type=str, default=None,
                         help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')

--- a/supervisor_checks/bin/memory_check.py
+++ b/supervisor_checks/bin/memory_check.py
@@ -27,7 +27,7 @@ def _make_argument_parser():
                         type=str, required=True, default=None,
                         help='Health check name.')
     parser.add_argument('-g', '--process-group', dest='process_group',
-                        type=str, required=True, default=None,
+                        type=str, default=None,
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,

--- a/supervisor_checks/bin/memory_check.py
+++ b/supervisor_checks/bin/memory_check.py
@@ -29,6 +29,10 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, required=True, default=None,
                         help='Supervisor process group name.')
+    parser.add_argument('-pn', '--process-name', dest='process_name',
+                        type=str, default=None,
+                        help='Supervisor process name. Process group argument is ignored if this' +
+                             'is passed in')
     parser.add_argument(
         '-m', '--msx-rss', dest='max_rss', type=int, required=True,
         help='Maximum memory allowed to use by process, KB.')
@@ -48,7 +52,7 @@ def main():
                                            'cumulative': args.cumulative})]
 
     return check_runner.CheckRunner(
-        args.check_name, args.process_group, checks_config).run()
+        args.check_name, args.process_group, args.process_name, checks_config).run()
 
 
 if __name__ == '__main__':

--- a/supervisor_checks/bin/memory_check.py
+++ b/supervisor_checks/bin/memory_check.py
@@ -31,7 +31,7 @@ def _make_argument_parser():
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,
-                        help='Supervisor process name. Process group argument is ignored if this' +
+                        help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')
     parser.add_argument(
         '-m', '--msx-rss', dest='max_rss', type=int, required=True,

--- a/supervisor_checks/bin/tcp_check.py
+++ b/supervisor_checks/bin/tcp_check.py
@@ -27,7 +27,7 @@ def _make_argument_parser():
                         type=str, required=True, default=None,
                         help='Check name.')
     parser.add_argument('-g', '--process-group', dest='process_group',
-                        type=str, required=True, default=None,
+                        type=str, default=None,
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,

--- a/supervisor_checks/bin/tcp_check.py
+++ b/supervisor_checks/bin/tcp_check.py
@@ -29,7 +29,7 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, default=None,
                         help='Supervisor process group name.')
-    parser.add_argument('-pn', '--process-name', dest='process_name',
+    parser.add_argument('-N', '--process-name', dest='process_name',
                         type=str, default=None,
                         help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')

--- a/supervisor_checks/bin/tcp_check.py
+++ b/supervisor_checks/bin/tcp_check.py
@@ -31,7 +31,7 @@ def _make_argument_parser():
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,
-                        help='Supervisor process name. Process group argument is ignored if this' +
+                        help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')
     parser.add_argument(
         '-p', '--port', dest='port', type=str,

--- a/supervisor_checks/bin/tcp_check.py
+++ b/supervisor_checks/bin/tcp_check.py
@@ -29,6 +29,10 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, required=True, default=None,
                         help='Supervisor process group name.')
+    parser.add_argument('-pn', '--process-name', dest='process_name',
+                        type=str, default=None,
+                        help='Supervisor process name. Process group argument is ignored if this' +
+                             'is passed in')
     parser.add_argument(
         '-p', '--port', dest='port', type=str,
         default=None, required=True,
@@ -56,7 +60,7 @@ def main():
                                      'port': args.port})]
 
     return check_runner.CheckRunner(
-        args.check_name, args.process_group, checks_config).run()
+        args.check_name, args.process_group, args.process_name, checks_config).run()
 
 
 if __name__ == '__main__':

--- a/supervisor_checks/bin/xmlrpc_check.py
+++ b/supervisor_checks/bin/xmlrpc_check.py
@@ -28,7 +28,7 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, default=None,
                         help='Supervisor process group name.')
-    parser.add_argument('-pn', '--process-name', dest='process_name',
+    parser.add_argument('-N', '--process-name', dest='process_name',
                         type=str, default=None,
                         help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')

--- a/supervisor_checks/bin/xmlrpc_check.py
+++ b/supervisor_checks/bin/xmlrpc_check.py
@@ -26,7 +26,7 @@ def _make_argument_parser():
                         type=str, required=True, default=None,
                         help='Health check name.')
     parser.add_argument('-g', '--process-group', dest='process_group',
-                        type=str, required=True, default=None,
+                        type=str, default=None,
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,

--- a/supervisor_checks/bin/xmlrpc_check.py
+++ b/supervisor_checks/bin/xmlrpc_check.py
@@ -30,7 +30,7 @@ def _make_argument_parser():
                         help='Supervisor process group name.')
     parser.add_argument('-pn', '--process-name', dest='process_name',
                         type=str, default=None,
-                        help='Supervisor process name. Process group argument is ignored if this' +
+                        help='Supervisor process name. Process group argument is ignored if this ' +
                              'is passed in')
     parser.add_argument('-u', '--url', dest='url', type=str,
                         help='XML RPC check url', required=False, default=None)

--- a/supervisor_checks/bin/xmlrpc_check.py
+++ b/supervisor_checks/bin/xmlrpc_check.py
@@ -28,6 +28,10 @@ def _make_argument_parser():
     parser.add_argument('-g', '--process-group', dest='process_group',
                         type=str, required=True, default=None,
                         help='Supervisor process group name.')
+    parser.add_argument('-pn', '--process-name', dest='process_name',
+                        type=str, default=None,
+                        help='Supervisor process name. Process group argument is ignored if this' +
+                             'is passed in')
     parser.add_argument('-u', '--url', dest='url', type=str,
                         help='XML RPC check url', required=False, default=None)
     parser.add_argument('-s', '--socket-path', dest='sock_path', type=str,
@@ -77,7 +81,7 @@ def main():
                                            })]
 
     return check_runner.CheckRunner(
-        args.check_name, args.process_group, checks_config).run()
+        args.check_name, args.process_group, args.process_name, checks_config).run()
 
 
 if __name__ == '__main__':

--- a/supervisor_checks/check_runner.py
+++ b/supervisor_checks/check_runner.py
@@ -11,7 +11,7 @@ import sys
 import threading
 
 from supervisor import childutils
-from supervisor.options import make_namespec
+from supervisor.options import make_namespec, split_namespec
 from supervisor.states import ProcessStates
 
 from supervisor_checks.compat import xmlrpclib
@@ -58,7 +58,7 @@ class CheckRunner(object):
         self._process_group = process_group
         # represents specific process name
         self._process_name = process_name
-        self._group_check_name = '%s_check' % (self._process_group,)
+        self._group_check_name = '%s_check' % (self._process_display_name(),)
         self._rpc_client = childutils.getRPCInterface(self._environment)
         self._stop_event = threading.Event()
 
@@ -66,8 +66,8 @@ class CheckRunner(object):
         """Run main check loop.
         """
 
-        self._log('Starting the health check for %s process group. '
-                  'Checks config: %s', self._process_group, self._checks_config)
+        self._log('Starting the health check for %s process '
+                  'Checks config: %s', self._process_display_name(), self._checks_config)
 
         self._install_signal_handlers()
 
@@ -78,7 +78,7 @@ class CheckRunner(object):
             except AboutToShutdown:
                 self._log(
                     'Health check for %s process group has been told to stop.',
-                    self._process_group)
+                    self._process_display_name())
 
                 break
 
@@ -107,7 +107,7 @@ class CheckRunner(object):
         else:
             self._log(
                 'No processes in state RUNNING found for process group %s',
-                self._process_group)
+                self._process_display_name())
 
     def _check_and_restart(self, process_spec):
         """Run checks for the process and restart if needed.
@@ -248,3 +248,6 @@ class CheckRunner(object):
                 return event_type
 
         raise AboutToShutdown
+
+    def _process_display_name(self):
+        return self._process_name or self._process_group

--- a/supervisor_checks/check_runner.py
+++ b/supervisor_checks/check_runner.py
@@ -77,7 +77,7 @@ class CheckRunner(object):
                 event_type = self._wait_for_supervisor_event()
             except AboutToShutdown:
                 self._log(
-                    'Health check for %s process group has been told to stop.',
+                    'Health check for %s process has been told to stop.',
                     self._process_display_name())
 
                 break
@@ -92,7 +92,7 @@ class CheckRunner(object):
         self._log('Done.')
 
     def _check_processes(self):
-        """Run single check loop for process group.
+        """Run single check loop for process group or name.
         """
 
         process_specs = self._get_process_spec_list(ProcessStates.RUNNING)
@@ -106,7 +106,7 @@ class CheckRunner(object):
                         pool.submit(self._check_and_restart, process_spec)
         else:
             self._log(
-                'No processes in state RUNNING found for process group %s',
+                'No processes in state RUNNING found for process %s',
                 self._process_display_name())
 
     def _check_and_restart(self, process_spec):
@@ -143,7 +143,7 @@ class CheckRunner(object):
         return checks
 
     def _get_process_spec_list(self, state=None):
-        """Get the list of processes in a process group.
+        """Get the list of processes in a process group or name.
 
         If process_name doesn't exist then get all processes in the defined group
         If process_name exists then get only the process(es) that match that name

--- a/supervisor_checks/check_runner.py
+++ b/supervisor_checks/check_runner.py
@@ -41,7 +41,7 @@ class CheckRunner(object):
     """SupervisorD checks runner.
     """
 
-    def __init__(self, check_name, process_group, checks_config, env=None):
+    def __init__(self, check_name, process_group, process_name, checks_config, env=None):
         """Constructor.
 
         :param str check_name: the name of check to display in log.
@@ -56,6 +56,8 @@ class CheckRunner(object):
         self._checks_config = checks_config
         self._checks = self._init_checks()
         self._process_group = process_group
+        # represents specific process name
+        self._process_name = process_name
         self._group_check_name = '%s_check' % (self._process_group,)
         self._rpc_client = childutils.getRPCInterface(self._environment)
         self._stop_event = threading.Event()
@@ -142,13 +144,22 @@ class CheckRunner(object):
 
     def _get_process_spec_list(self, state=None):
         """Get the list of processes in a process group.
+
+        If process_name doesn't exist then get all processes in the defined group
+        If process_name exists then get only the process(es) that match that name
         """
 
         process_specs = []
         for process_spec in self._rpc_client.supervisor.getAllProcessInfo():
-            if (process_spec[GROUP_KEY] == self._process_group and
+            if not self._process_name:
+                if (process_spec[GROUP_KEY] == self._process_group and
                     (state is None or process_spec[STATE_KEY] == state)):
-                process_specs.append(process_spec)
+                    process_specs.append(process_spec)
+            else:
+                if ((process_spec[GROUP_KEY], process_spec[NAME_KEY]) == 
+                    split_namespec(self._process_name) and
+                    (state is None or process_spec[STATE_KEY] == state)):
+                    process_specs.append(process_spec)
 
         return process_specs
 
@@ -156,8 +167,12 @@ class CheckRunner(object):
         """Restart a process.
         """
 
-        name_spec = make_namespec(
-            process_spec[GROUP_KEY], process_spec[NAME_KEY])
+        if not self._process_name:
+            name_spec = make_namespec(
+                process_spec[GROUP_KEY], process_spec[NAME_KEY])
+        else:
+            name_spec_tuple = split_namespec(self._process_name)
+            name_spec = make_namespec(name_spec_tuple[0], name_spec_tuple[1])
 
         rpc_client = childutils.getRPCInterface(self._environment)
 


### PR DESCRIPTION
Instead of being dependent on always passing in a group, sometimes you just want to track a single process that may be in a group of processes. This is so that we don't need to reorg our supervisor config and just pass in the exact process name in a group, exactly like how we would target a specific service in a group.