### PR TITLE
[fix] Fix signal safety in check_runner signal handler

### DIFF
--- a/supervisor_checks/check_runner.py
+++ b/supervisor_checks/check_runner.py
@@ -222,8 +222,6 @@ class CheckRunner(object):
         """Signal handler.
         """
 
-        self._log('Got signal %s', signum)
-
         self._stop_event.set()
 
     def _wait_for_supervisor_event(self):


### PR DESCRIPTION
The check_runner signal handler logs the received signal number. This causes some problems as printing to stdout/stderr is not a signal safe action.