### PR TITLE
[enh] Add File based health check module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here's the list of check programs package provides out-of-box:
 * _supervisor_xmlrpc_check_: process check based on call to XML-RPC server.
 * _supervisor_memory_check_: process check based on amount of memory consumed by process.
 * _supervisor_cpu_check_: process check based on CPU percent usage within time interval.
-* _supervisor_file_check_: process check based on file update timeout.
+* _supervisor_file_check_: process check based on file update timeout. (Only UNIX)
 * _supervisor_complex_check_: complex check (run multiple checks at once).
 
 For now, it is developed and supposed to work primarily with Python 3 and

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Here's the list of check programs package provides out-of-box:
 * _supervisor_xmlrpc_check_: process check based on call to XML-RPC server.
 * _supervisor_memory_check_: process check based on amount of memory consumed by process.
 * _supervisor_cpu_check_: process check based on CPU percent usage within time interval.
+* _supervisor_file_check_: process check based on file update timeout.
 * _supervisor_complex_check_: complex check (run multiple checks at once).
 
 For now, it is developed and supposed to work primarily with Python 3 and
@@ -329,6 +330,52 @@ Restart process when it consumes more than 100% CPU within 30 minutes:
     command=/usr/local/bin/supervisor_cpu_check -n example_check -p 100 -i 1800 -g example_service
     events=TICK_60
 
+
+### File Check
+
+Process check based on file update timeout.
+
+#### CLI
+
+    $ /usr/local/bin/supervisor_file_check -h
+    usage: supervisor_file_check [-h] -n CHECK_NAME [-g PROCESS_GROUP] [-N PROCESS_NAME] -t TIMEOUT [-x] [-f FILE]
+    Run File check program.
+    
+    optional arguments:
+      -h, --help            show this help message and exit
+      -n CHECK_NAME, --check-name CHECK_NAME
+                            Health check name.
+      -g PROCESS_GROUP, --process-group PROCESS_GROUP
+                            Supervisor process group name.
+      -N PROCESS_NAME, --process-name PROCESS_NAME
+                            Supervisor process name. Process group argument is
+                            ignored if this is passed in
+      -t TIMEOUT, --timeout TIMEOUT
+                            Timeout in seconds after no file change a process is considered dead.
+      -x, --fail-on-error   Fail the health check on any error.
+      -f FILE, --file FILE  Filepath of file to check (default:
+                        /tmp/supervisor_checks/%(process_group)s-%(process_name)s-%(process_pid)s)
+#### Configuration Examples
+
+Restart process when it consumes more than 100% CPU within 30 minutes:
+
+    [eventlistener:example_check]
+    command=/usr/local/bin/supervisor_file_check -n example_check -t 30
+    events=TICK_60
+
+#### NotificationFile Utility Class
+
+To simplify the work with this health check module, an utility class is provided to update the notification file associated with the current supervisor subprocess and notify an heartbeat.
+
+```python
+from supervisor_checks.util import NotificationFile
+
+tmp = NotificationFile()
+
+while True:
+    tmp.notify()
+    # do some work here
+```
 
 ### Complex Check
 

--- a/README.md
+++ b/README.md
@@ -339,25 +339,28 @@ Process check based on file update timeout.
 
     $ /usr/local/bin/supervisor_file_check -h
     usage: supervisor_file_check [-h] -n CHECK_NAME [-g PROCESS_GROUP] [-N PROCESS_NAME] -t TIMEOUT [-x] [-f FILE]
+
     Run File check program.
     
-    optional arguments:
+    options:
       -h, --help            show this help message and exit
       -n CHECK_NAME, --check-name CHECK_NAME
                             Health check name.
       -g PROCESS_GROUP, --process-group PROCESS_GROUP
                             Supervisor process group name.
       -N PROCESS_NAME, --process-name PROCESS_NAME
-                            Supervisor process name. Process group argument is
-                            ignored if this is passed in
+                            Supervisor process name. Process group argument is ignored if this is passed in
       -t TIMEOUT, --timeout TIMEOUT
                             Timeout in seconds after no file change a process is considered dead.
       -x, --fail-on-error   Fail the health check on any error.
-      -f FILE, --file FILE  Filepath of file to check (default:
-                        /tmp/supervisor_checks/%(process_group)s-%(process_name)s-%(process_pid)s)
+      -f FILEPATH, --filepath FILEPATH
+                            Filepath of file to check (default:
+                            %(root_directory)/%(process_group)s-%(process_name)s-%(process_pid)s-*)
+      -d ROOT_DIR, --root-dir ROOT_DIR
+                            Root Directory of Notification Files (default: tempfile.gettempdir())
 #### Configuration Examples
 
-Restart process when it consumes more than 100% CPU within 30 minutes:
+Perform passive health checks on default root_directory, allowing a maximum of 30 seconds health notification delay.
 
     [eventlistener:example_check]
     command=/usr/local/bin/supervisor_file_check -n example_check -t 30

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
             'supervisor_http_check=supervisor_checks.bin.http_check:main',
             'supervisor_tcp_check=supervisor_checks.bin.tcp_check:main',
             'supervisor_xmlrpc_check=supervisor_checks.bin.xmlrpc_check:main',
-            'supervisor_complex_check=supervisor_checks.bin.complex_check:main']
+            'supervisor_complex_check=supervisor_checks.bin.complex_check:main',
+            'supervisor_file_check=supervisor_checks.bin.file_check:main']
     }
 )
 

--- a/supervisor_checks/bin/file_check.py
+++ b/supervisor_checks/bin/file_check.py
@@ -1,0 +1,45 @@
+
+import argparse
+import sys
+
+from supervisor_checks import check_runner
+from supervisor_checks.check_modules import file
+
+
+def _make_argument_parser():
+    """Create the option parser.
+    """
+
+    parser = argparse.ArgumentParser(
+        description='Run File check program.')
+    parser.add_argument('-n', '--check-name', dest='check_name',
+                        type=str, required=True, default=None,
+                        help='Health check name.')
+    parser.add_argument('-g', '--process-group', dest='process_group',
+                        type=str, default=None,
+                        help='Supervisor process group name.')
+    parser.add_argument('-N', '--process-name', dest='process_name',
+                        type=str, default=None,
+                        help='Supervisor process name. Process group argument is ignored if this ' +
+                             'is passed in')
+    parser.add_argument(
+        '-t', '--timeout', dest='timeout', type=int, required=True,
+        help='Timeout in seconds after no file change a process is considered dead.')
+    parser.add_argument("-x", "--fail-on-error", dest="fail_on_error", action="store_true", help="Fail the health check on any error.")
+    parser.add_argument("-f", "--file", dest="file", type=str, default=None, help="Filepath of file to check (default: /tmp/supervisor_checks/%%(process_group)s-%%(process_name)s-%%(process_pid)s-*)")
+    return parser
+
+
+def main():
+
+    arg_parser = _make_argument_parser()
+    args = arg_parser.parse_args()
+
+    checks_config = [(file.FileCheck, {'timeout': args.timeout, 'fail_on_error': args.fail_on_error, 'file': args.file})]
+    return check_runner.CheckRunner(
+        args.check_name, args.process_group, args.process_name, checks_config).run()
+
+
+if __name__ == '__main__':
+
+    sys.exit(main())

--- a/supervisor_checks/bin/file_check.py
+++ b/supervisor_checks/bin/file_check.py
@@ -26,7 +26,8 @@ def _make_argument_parser():
         '-t', '--timeout', dest='timeout', type=int, required=True,
         help='Timeout in seconds after no file change a process is considered dead.')
     parser.add_argument("-x", "--fail-on-error", dest="fail_on_error", action="store_true", help="Fail the health check on any error.")
-    parser.add_argument("-f", "--file", dest="file", type=str, default=None, help="Filepath of file to check (default: /tmp/supervisor_checks/%%(process_group)s-%%(process_name)s-%%(process_pid)s-*)")
+    parser.add_argument("-f", "--filepath", dest="filepath", type=str, default=None, help="Filepath of file to check (default: %%(root_directory)/%%(process_group)s-%%(process_name)s-%%(process_pid)s-*)")
+    parser.add_argument("-d", "--root-dir", dest="root_dir", type=str, default=None, help="Root Directory of Notification Files (default: tempfile.gettempdir())")
     return parser
 
 
@@ -35,7 +36,7 @@ def main():
     arg_parser = _make_argument_parser()
     args = arg_parser.parse_args()
 
-    checks_config = [(file.FileCheck, {'timeout': args.timeout, 'fail_on_error': args.fail_on_error, 'file': args.file})]
+    checks_config = [(file.FileCheck, {'timeout': args.timeout, 'fail_on_error': args.fail_on_error, 'filepath': args.filepath, 'root_dir': args.root_dir})]
     return check_runner.CheckRunner(
         args.check_name, args.process_group, args.process_name, checks_config).run()
 

--- a/supervisor_checks/check_modules/file.py
+++ b/supervisor_checks/check_modules/file.py
@@ -1,0 +1,43 @@
+import time
+import os
+from supervisor_checks import errors
+from supervisor_checks import utils
+from supervisor_checks.check_modules import base
+
+
+class FileCheck(base.BaseCheck):
+    NAME = "file"
+
+    def __call__(self, process_spec):
+        notification_filepath = self._config["file"]
+        if notification_filepath is None:
+            notification_filepath = utils.NotificationFile.get_filepath(process_spec["group"], process_spec["name"], process_spec["pid"])
+
+        try:
+            stat = os.stat(notification_filepath, follow_symlinks=False)
+            return time.time() - stat.st_ctime <= self._config["timeout"]
+        except OSError:
+            self._log("ERROR: Could not stat file: %s" % (notification_filepath,))
+            return not self._config["fail_on_error"]
+
+
+    def _validate_config(self):
+        if "timeout" not in self._config:
+            raise errors.InvalidCheckConfig(
+                'Required `timeout` parameter is missing in %s check config.' % (
+                    self.NAME,))
+        
+        if not isinstance(self._config['timeout'], int):
+            raise errors.InvalidCheckConfig(
+                '`timeout` parameter must be int type in %s check config.' % (
+                    self.NAME,))
+
+        if "fail_on_error" not in self._config:
+            raise errors.InvalidCheckConfig(
+                'Required `fail_on_error` parameter is missing in %s check config.' % (
+                    self.NAME,))
+
+        if "file" not in self._config:
+            raise errors.InvalidCheckConfig(
+                'Required `file` parameter is missing in %s check config.' % (
+                    self.NAME,))

--- a/supervisor_checks/check_modules/file.py
+++ b/supervisor_checks/check_modules/file.py
@@ -9,9 +9,9 @@ class FileCheck(base.BaseCheck):
     NAME = "file"
 
     def __call__(self, process_spec):
-        notification_filepath = self._config["file"]
+        notification_filepath = self._config["filepath"]
         if notification_filepath is None:
-            notification_filepath = utils.NotificationFile.get_filepath(process_spec["group"], process_spec["name"], process_spec["pid"])
+            notification_filepath = utils.NotificationFile.get_filepath(self._config["root_dir"], process_spec["group"], process_spec["name"], process_spec["pid"])
 
         try:
             stat = os.stat(notification_filepath, follow_symlinks=False)
@@ -37,7 +37,12 @@ class FileCheck(base.BaseCheck):
                 'Required `fail_on_error` parameter is missing in %s check config.' % (
                     self.NAME,))
 
-        if "file" not in self._config:
+        if "filepath" not in self._config:
             raise errors.InvalidCheckConfig(
-                'Required `file` parameter is missing in %s check config.' % (
+                'Required `filepath` parameter is missing in %s check config.' % (
+                    self.NAME,))
+
+        if "root_dir" not in self._config:
+            raise errors.InvalidCheckConfig(
+                'Required `root_dir` parameter is missing in %s check config.' % (
                     self.NAME,))

--- a/supervisor_checks/utils.py
+++ b/supervisor_checks/utils.py
@@ -206,7 +206,6 @@ class NotificationFile:
     def get_tempdir():
         return os.path.join(tempfile.gettempdir(), "supervisor_checks")
 
-
     @staticmethod
     def get_filename(process_group, process_name, pid):
         return f"{process_group!s}-{process_name!s}-{pid!s}"

--- a/supervisor_checks/utils.py
+++ b/supervisor_checks/utils.py
@@ -91,53 +91,6 @@ def get_port(port_or_port_re, process_name):
         'expression %s' % (process_name, port_or_port_re))
 
 
-
-
-# Directly copied from the tempfile module
-class _TemporaryFileCloser:
-    """A separate object allowing proper closing of a temporary file's
-    underlying file object, without adding a __del__ method to the
-    temporary file."""
-
-    file = None  # Set here since __del__ checks it
-    close_called = False
-
-    def __init__(self, file, name, delete=True):
-        self.file = file
-        self.name = name
-        self.delete = delete
-
-    # NT provides delete-on-close as a primitive, so we don't need
-    # the wrapper to do anything special.  We still use it so that
-    # file.name is useful (i.e. not "(fdopen)") with NamedTemporaryFile.
-    if os.name != 'nt':
-        # Cache the unlinker so we don't get spurious errors at
-        # shutdown when the module-level "os" is None'd out.  Note
-        # that this must be referenced as self.unlink, because the
-        # name TemporaryFileWrapper may also get None'd out before
-        # __del__ is called.
-
-        def close(self, unlink=os.unlink):
-            if not self.close_called and self.file is not None:
-                self.close_called = True
-                try:
-                    self.file.close()
-                finally:
-                    if self.delete:
-                        unlink(self.name)
-
-        # Need to ensure the file is deleted on __del__
-        def __del__(self):
-            self.close()
-
-    else:
-        def close(self):
-            if not self.close_called:
-                self.close_called = True
-                self.file.close()
-
-
-# Directly copied from the tempfile module
 class _TemporaryFileWrapper:
     """Temporary file wrapper
 
@@ -150,56 +103,27 @@ class _TemporaryFileWrapper:
         self.file = file
         self.name = name
         self.delete = delete
-        self._closer = _TemporaryFileCloser(file, name, delete)
+        self.close_called = False
 
     def __getattr__(self, name):
-        # Attribute lookups are delegated to the underlying file
-        # and cached for non-numeric results
-        # (i.e. methods are cached, closed and friends are not)
-        file = self.__dict__['file']
-        a = getattr(file, name)
-        if hasattr(a, '__call__'):
-            func = a
-            @functools.wraps(func)
-            def func_wrapper(*args, **kwargs):
-                return func(*args, **kwargs)
-            # Avoid closing the file as long as the wrapper is alive,
-            # see issue #18879.
-            func_wrapper._closer = self._closer
-            a = func_wrapper
-        if not isinstance(a, int):
-            setattr(self, name, a)
-        return a
+        return getattr(self.file, name)
 
-    # The underlying __enter__ method returns the wrong object
-    # (self.file) so override it to return the wrapper
-    def __enter__(self):
-        self.file.__enter__()
-        return self
+    def close(self, unlink=os.unlink):
+        if not self.close_called and self.file is not None:
+            self.close_called = True
+            try:
+                self.file.close()
+            finally:
+                if self.delete:
+                    unlink(self.name)
 
-    # Need to trap __exit__ as well to ensure the file gets
-    # deleted when used in a with statement
-    def __exit__(self, exc, value, tb):
-        result = self.file.__exit__(exc, value, tb)
+    def __del__(self):
         self.close()
-        return result
 
-    def close(self):
-        """
-        Close the temporary file, possibly deleting it.
-        """
-        self._closer.close()
 
-    # iter() doesn't use __getattr__ to find the __iter__ method
-    def __iter__(self):
-        # Don't return iter(self.file), but yield from it to avoid closing
-        # file as long as it's being used as iterator (see issue #23700).  We
-        # can't use 'yield from' here because iter(file) returns the file
-        # object itself, which has a close method, and thus the file would get
-        # closed when the generator is finalized, due to PEP380 semantics.
-        for line in self.file:
-            yield line
-
+_open_flags = os.O_CREAT
+if hasattr(os, "O_NOFOLLOW"):
+    _open_flags |= os.O_NOFOLLOW
 
 class NotificationFile:
     @staticmethod
@@ -217,6 +141,7 @@ class NotificationFile:
     def __init__(self, filepath=None, root_dir=None, delete=True):
         """
         Creates a NotificationFile object used to indicate a heartbeat.
+        Only supports UNIX.
 
         param str filepath: optional filepath to use as notification file
         param str root_dir: optional root_dir to use for the notification file (default: tempfile.gettempdir())
@@ -226,8 +151,7 @@ class NotificationFile:
             filepath = self.get_filepath(root_dir=root_dir)
 
         def opener(file, flags):
-            flags |= os.O_NOFOLLOW
-            flags |= os.O_CREAT
+            flags |= _open_flags
             return os.open(file, flags, mode=0o000)
 
         fd = open(filepath, "rb", buffering=0, opener=opener)

--- a/supervisor_checks/utils.py
+++ b/supervisor_checks/utils.py
@@ -6,6 +6,8 @@ import contextlib
 import functools
 import re
 import time
+import os
+import tempfile
 
 from supervisor_checks import errors
 
@@ -87,3 +89,161 @@ def get_port(port_or_port_re, process_name):
     raise errors.InvalidCheckConfig(
         'Could not extract port number for process name %s using regular '
         'expression %s' % (process_name, port_or_port_re))
+
+
+
+
+# Directly copied from the tempfile module
+class _TemporaryFileCloser:
+    """A separate object allowing proper closing of a temporary file's
+    underlying file object, without adding a __del__ method to the
+    temporary file."""
+
+    file = None  # Set here since __del__ checks it
+    close_called = False
+
+    def __init__(self, file, name, delete=True):
+        self.file = file
+        self.name = name
+        self.delete = delete
+
+    # NT provides delete-on-close as a primitive, so we don't need
+    # the wrapper to do anything special.  We still use it so that
+    # file.name is useful (i.e. not "(fdopen)") with NamedTemporaryFile.
+    if os.name != 'nt':
+        # Cache the unlinker so we don't get spurious errors at
+        # shutdown when the module-level "os" is None'd out.  Note
+        # that this must be referenced as self.unlink, because the
+        # name TemporaryFileWrapper may also get None'd out before
+        # __del__ is called.
+
+        def close(self, unlink=os.unlink):
+            if not self.close_called and self.file is not None:
+                self.close_called = True
+                try:
+                    self.file.close()
+                finally:
+                    if self.delete:
+                        unlink(self.name)
+
+        # Need to ensure the file is deleted on __del__
+        def __del__(self):
+            self.close()
+
+    else:
+        def close(self):
+            if not self.close_called:
+                self.close_called = True
+                self.file.close()
+
+
+# Directly copied from the tempfile module
+class _TemporaryFileWrapper:
+    """Temporary file wrapper
+
+    This class provides a wrapper around files opened for
+    temporary use.  In particular, it seeks to automatically
+    remove the file when it is no longer needed.
+    """
+
+    def __init__(self, file, name, delete=True):
+        self.file = file
+        self.name = name
+        self.delete = delete
+        self._closer = _TemporaryFileCloser(file, name, delete)
+
+    def __getattr__(self, name):
+        # Attribute lookups are delegated to the underlying file
+        # and cached for non-numeric results
+        # (i.e. methods are cached, closed and friends are not)
+        file = self.__dict__['file']
+        a = getattr(file, name)
+        if hasattr(a, '__call__'):
+            func = a
+            @functools.wraps(func)
+            def func_wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+            # Avoid closing the file as long as the wrapper is alive,
+            # see issue #18879.
+            func_wrapper._closer = self._closer
+            a = func_wrapper
+        if not isinstance(a, int):
+            setattr(self, name, a)
+        return a
+
+    # The underlying __enter__ method returns the wrong object
+    # (self.file) so override it to return the wrapper
+    def __enter__(self):
+        self.file.__enter__()
+        return self
+
+    # Need to trap __exit__ as well to ensure the file gets
+    # deleted when used in a with statement
+    def __exit__(self, exc, value, tb):
+        result = self.file.__exit__(exc, value, tb)
+        self.close()
+        return result
+
+    def close(self):
+        """
+        Close the temporary file, possibly deleting it.
+        """
+        self._closer.close()
+
+    # iter() doesn't use __getattr__ to find the __iter__ method
+    def __iter__(self):
+        # Don't return iter(self.file), but yield from it to avoid closing
+        # file as long as it's being used as iterator (see issue #23700).  We
+        # can't use 'yield from' here because iter(file) returns the file
+        # object itself, which has a close method, and thus the file would get
+        # closed when the generator is finalized, due to PEP380 semantics.
+        for line in self.file:
+            yield line
+
+
+class NotificationFile:
+    @staticmethod
+    def get_tempdir():
+        return os.path.join(tempfile.gettempdir(), "supervisor_checks")
+
+
+    @staticmethod
+    def get_filename(process_group, process_name, pid):
+        return f"{process_group!s}-{process_name!s}-{pid!s}"
+
+    @staticmethod
+    def get_filepath(process_group, process_name, pid):
+        return os.path.join(NotificationFile.get_tempdir(), NotificationFile.get_filename(process_group, process_name, pid))
+
+    @staticmethod
+    def get_filepath_within_subprocess():
+        return os.path.join(NotificationFile.get_tempdir(), NotificationFile.get_filename(os.getenv("SUPERVISOR_GROUP_NAME"), os.getenv("SUPERVISOR_PROCESS_NAME"), os.getpid()))
+
+    def __init__(self, filepath=None, delete=True):
+        """
+        Creates a NotificationFile object used to indicate a heartbeat.
+
+        param str filepath: optional filepath to use as notification file
+        param bool delete: wether to delete the notification file after fd is closed 
+        """
+        if filepath is None:
+            if not os.path.exists(self.get_tempdir()):
+                os.mkdir(self.get_tempdir())
+            filepath = self.get_filepath_within_subprocess()
+
+        def opener(file, flags):
+            flags |= os.O_NOFOLLOW
+            flags |= os.O_CREAT
+            return os.open(file, flags, mode=0o000)
+
+        fd = open(filepath, "rb", buffering=0, opener=opener)
+        self._tmp = _TemporaryFileWrapper(fd, filepath, delete=delete)
+
+        self.spinner = 0
+
+    def notify(self):
+        self.spinner = (self.spinner + 1) % 2
+        os.fchmod(self._tmp.fileno(), self.spinner)
+
+    def close(self):
+        return self._tmp.close()


### PR DESCRIPTION
This health check module works by comparing the difference of the last time a file was modified and the current time to a configurable timeout. If the difference is greater than the timeout, the health check fails.

This implements a _passive_ health check system in which the supervisor subprocess notifies with an hearbeat that it is still alive as opposed to an _active_ health check system in which the check process actively makes a HTTP Request for example.